### PR TITLE
986064: Resolve Failures in GitHub Repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # javascript-scheduler-ruby-rails-application
 
-This repository provides a sample integration of the Syncfusion JavaScript Scheduler component within a Ruby on Rails application using React.
+This repository provides a sample integration of the Syncfusion JavaScript Scheduler component within a Ruby on Rails application.
 
 ## Prerequisites
 
@@ -25,7 +25,7 @@ gem install rails
 
 ## Add Syncfusion Scheduler component in your application
 
-Refer to the following UG documenation for adding Syncfusion React component in your application
+Refer to the following UG documenation for adding Syncfusion Javascript component in your application
 * [Getting Started of Syncfusion Javascript Scheduler component](https://ej2.syncfusion.com/javascript/documentation/schedule/getting-started)
 
 ## Run the project

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # javascript-scheduler-ruby-rails-application
 
+This repository provides a sample integration of the Syncfusion JavaScript Scheduler component within a Ruby on Rails application using React.
+
 ## Prerequisites
+
+Ensure the following versions are installed on your system before proceeding:
 
 Ruby - 3.2.2
 Node Js - 18.13.0
@@ -13,16 +17,20 @@ You can install the Ruby from the following link.
 
 ## Install Rails
 
+To install Rails globally, run the following command:
+
 ```
 gem install rails
 ```
 
 ## Add Syncfusion Scheduler component in your application
 
-Refer the following UG documenation for adding Syncfusion React component in your application
+Refer to the following UG documenation for adding Syncfusion React component in your application
 * [Getting Started of Syncfusion Javascript Scheduler component](https://ej2.syncfusion.com/javascript/documentation/schedule/getting-started)
 
 ## Run the project
+
+To start the application, execute the following commands:
 
 ```
 yarn install


### PR DESCRIPTION
### Bug description
[986064](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/986064/): Resolve Failures in GitHub Repositories

### Root cause,
The repository readme must have a minimum length of 1000 characters, whereas the current readme length is only 865 characters

### Reason for not identifying earlier
Find how it was missed in our earlier testing and development by analysing the below checklist. This will help prevent similar mistakes in the future. 

 - [x] Guidelines/documents are not followed

    - Specification document

 - [ ] Guidelines/documents are not given

    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

I have resolved by add the content in Readme description.

### Output screenshots:

NA

### Action taken:

I have resolved by add the content in Readme description.

### Related areas:

NA

### Is it a breaking issue?

No

### Solution description

I have resolved by add the content in Readme description.

### Areas affected and ensured

NA

### Additional checklist
This may vary for different teams or products. Check with your scrum masters.

  - Did you run the automation against your fix? Yes
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA
  - 